### PR TITLE
Increase pathlen constant

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,6 @@
-# Install
+# Installation
+
+Instructions on how to build and install cscope used for [buttercup](https://github.com/trailofbits/buttercup).
 
 ## Download
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -64,7 +64,7 @@
 #define	DUMMYCHAR	' '	/* use space as a dummy character */
 #define	MSGLEN	((PATLEN) + 80)	/* displayed message length */
 #define	NUMLEN	10		/* line number length */
-#define	PATHLEN	250		/* file pathname length */
+#define	PATHLEN	4096		/* file pathname length */
 #define	PATLEN	250		/* symbol pattern length */
 #define TEMPSTRING_LEN 8191     /* max strlen() of the global temp string */
 #define	REFFILE	"cscope.out"	/* cross-reference output file */


### PR DESCRIPTION
Closes #2 

In general, `PATH_MAX` is defined as 4096 characters in [linux/limits.h](https://github.com/torvalds/linux/blob/0cc53520e68bea7fb80fdc6bdf8d226d1b6a98d9/include/uapi/linux/limits.h#L13). We can use the same value here.